### PR TITLE
bugfix to behavior at the last line of the term

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -509,15 +509,10 @@ terminal_move_to_line(EditLine *el, int where)
 		return;
 	}
 	if ((del = where - el->el_cursor.v) > 0) {
-		if ((del > 1) && GoodStr(T_DO)) {
-			terminal_tputs(el, tgoto(Str(T_DO), del, del), del);
-			del = 0;
-		} else {
-			for (; del > 0; del--)
-				terminal__putc(el, '\n');
-			/* because the \n will become \r\n */
-			el->el_cursor.h = 0;
-		}
+		for (; del > 0; del--)
+			terminal__putc(el, '\n');
+		/* because the \n will become \r\n */
+		el->el_cursor.h = 0;
 	} else {		/* del < 0 */
 		if (GoodStr(T_UP) && (-del > 1 || !GoodStr(T_up)))
 			terminal_tputs(el, tgoto(Str(T_UP), -del, -del), -del);


### PR DESCRIPTION
Previously, trying to do operations that caused calls to
`terminal_move_to_line` when the cursor was at the bottom of the
terminal and the target line was more than 1 line before the bottom of
the terminal would produce undefined behavior.

The reason for this was that the algorithm for `terminal_move_to_line`
used the DO termcap (aka cud or parm_down_cursor), which produces
undefined behavior when the cursor is on the last line. See the manual
here [0], which says:

> `DO', `UP', `LE', `RI'
> Strings of commands to move the cursor n lines down vertically, up
> vertically, or n columns left or right. Do not attempt to move past any
> edge of the screen with these commands; the effect of trying that is
> undefined. Only a few terminal descriptions provide these commands, and
> most programs do not use them.

Now, the `terminal_move_to_line` algorithm falls back to the code it
used in the case of only a single line movement, which is to output a
`\n` character in a loop, correcting the behavior.

[0]: https://www.gnu.org/software/termutils/manual/termcap-1.3/html_chapter/termcap_4.html#SEC23



I'll try to upstream this later. For reviewers trying to understand why `DO` is not appropriate on the last line, I encourage you to try running `tput cud 5` while on the last line of your terminal versus somewhere higher up. That command outputs a `DO` cap with an argument of 5, which should move the cursor 5 lines down. This will work as long as the cursor doesn't hit the last line. 

Shoutouts to @benesch for helping me understand this issue.